### PR TITLE
網頁呈現現代化

### DIFF
--- a/webdata/stdlibs/pixframework/Pix/Table/Db/Adapter/ElasticSearch.php
+++ b/webdata/stdlibs/pixframework/Pix/Table/Db/Adapter/ElasticSearch.php
@@ -2,7 +2,7 @@
 
 /**
  * Pix_Table_Db_Adapter_ElasticSearch
- * 
+ *
  * @package Table
  * @copyright 2003-2012 PIXNET Digital Media Corporation
  * @license http://framework.pixnet.net/license BSD License
@@ -40,7 +40,6 @@ class Pix_Table_Db_Adapter_ElasticSearch extends Pix_Table_Db_Adapter_Abstract
      */
     public function insertOne($table, $keys_values)
     {
-        $this->http(
         $db = $this->_getDb();
         $items = array();
         $excepted = array();

--- a/webdata/views/common/footer.phtml
+++ b/webdata/views/common/footer.phtml
@@ -1,4 +1,3 @@
-    </div><!-- .row-fluid -->
 </main><!-- .container -->
 </body>
 </html>

--- a/webdata/views/common/footer.phtml
+++ b/webdata/views/common/footer.phtml
@@ -1,4 +1,4 @@
 </div><!-- .row-fluid -->
-</div><!-- .container -->
+</main><!-- .container -->
 </body>
 </html>

--- a/webdata/views/common/footer.phtml
+++ b/webdata/views/common/footer.phtml
@@ -1,4 +1,4 @@
-</div><!-- .row-fluid -->
+    </div><!-- .row-fluid -->
 </main><!-- .container -->
 </body>
 </html>

--- a/webdata/views/common/header.phtml
+++ b/webdata/views/common/header.phtml
@@ -14,13 +14,14 @@ $title_terms[] = 'slack archive';
 <!DOCTYPE html>
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title><?= $this->escape(implode(' | ', $title_terms)) ?></title>
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
-<script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/2.2.2/bootstrap.min.js"></script>
-<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/2.2.2/css/bootstrap.css">
-<script type="text/javascript">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js" integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
+<script src="https://code.jquery.com/jquery-3.7.1.slim.min.js" integrity="sha256-kmHvs0B+OpCW5GVHUNjv9rOmY0IvSIRcf7zGUDTDQM8=" crossorigin="anonymous"></script>
 <?php if (getenv('GOOGLEANALYTICS_ACCOUNT')) { ?>
+<script type="text/javascript">
 var _gaq = _gaq || [];
 _gaq.push(['_setAccount', <?= json_encode(getenv('GOOGLEANALYTICS_ACCOUNT')) ?>]);
 _gaq.push(['_trackPageview']);
@@ -30,8 +31,8 @@ _gaq.push(['_trackPageview']);
     ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
     var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
 })();
-<?php } ?>
 </script>
+<?php } ?>
 </head>
 <body class="<?= $this->escape($this->body_class) ?>">
 <div class="navbar">

--- a/webdata/views/common/header.phtml
+++ b/webdata/views/common/header.phtml
@@ -18,6 +18,7 @@ $title_terms[] = 'slack archive';
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title><?= $this->escape(implode(' | ', $title_terms)) ?></title>
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css">
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js" integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
 <script src="https://code.jquery.com/jquery-3.7.1.slim.min.js" integrity="sha256-kmHvs0B+OpCW5GVHUNjv9rOmY0IvSIRcf7zGUDTDQM8=" crossorigin="anonymous"></script>
 <?php if (getenv('GOOGLEANALYTICS_ACCOUNT')) { ?>
@@ -35,33 +36,33 @@ _gaq.push(['_trackPageview']);
 <?php } ?>
 </head>
 <body class="<?= $this->escape($this->body_class) ?>">
-<div class="navbar">
-    <div class="navbar-inner">
-        <a class="brand" href="/">Slack archive</a>
-        <ul class="nav">
-            <li>
-            <a href="/">Channels</a>
-            </li>
-            <li>
-            <a href="https://github.com/ronnywang/g0v-slack-archive">Source Code</a>
-            </li>
-            <?php if ($this->user) { ?>
-            <li class="dropdown">
-            <a data-toggle="dropdown" class="dropdown-toggle" href="#">Hi! <?= $this->escape($this->user->name) ?><b class="caret"></b></a>
-            <ul class="dropdown-menu">
-                <li class="divider"></li>
-                <li><a href="/index/logout">登出</a></li>
+<div class="navbar sticky-top navbar-expand-lg bg-body-secondary">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="/">Slack archive</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarToggle" aria-controls="navbarToggle" aria-expanded="false" aria-label="Navigation">
+              <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarToggle">
+            <ul class="navbar-nav me-auto">
+                <li class="nav-item">
+                    <a class="nav-link" href="https://github.com/ronnywang/g0v-slack-archive"><i class="bi bi-github" aria-hidden></i><span class="ms-2 d-md-none">Source Code</span></a>
+                </li>
+                <?php if ($this->user) { ?>
+                <li class="nav-item dropdown">
+                    <button class="btn dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><i class="bi bi-person-check-fill" aria-hidden></i><span class="ms-2 d-md-none">Authenticated</span></button>
+                    <ul class="dropdown-menu">
+                        <li><h6 class="dropdown-header">Hi <?= $this->escape($this->user->name) ?>!</h6></li>
+                        <li><a class="dropdown-item" href="/index/logout">Logout</a></li>
+                    </ul>
+                </li>
+                <?php } else { ?>
+                <li class="nav-item">
+                    <a class="nav-link" href="/index/login/"><i class="bi bi-slack me-2" aria-hidden></i>Login with Slack</a>
+                </li>
+                <?php } ?>
             </ul>
-            </li>
-            <?php } else { ?>
-            <li>
-            <a href="/index/login/">Login with Slack</a>
-            </li>
-            <?php } ?>
-        </ul>
-        <div class="nav-collapse collapse">
-            <form class="navbar-form pull-right" method="get" action="/index/search">
-                <input type="text" name="q" placeholder="search">
+            <form class="d-flex" role="search" method="get" action="/index/search">
+                <input class="form-control me-2" type="search" name="q" placeholder="Search">
             </form>
         </div>
     </div>

--- a/webdata/views/common/header.phtml
+++ b/webdata/views/common/header.phtml
@@ -69,4 +69,3 @@ _gaq.push(['_trackPageview']);
     </div>
 </nav>
 <main class="container-fluid">
-    <div class="row-fluid">

--- a/webdata/views/common/header.phtml
+++ b/webdata/views/common/header.phtml
@@ -1,6 +1,6 @@
 <?php
 
-$title_terms = array();
+$title_terms = [];
 if ($this->title) {
     $title_terms[] = $this->title;
 }

--- a/webdata/views/common/header.phtml
+++ b/webdata/views/common/header.phtml
@@ -36,20 +36,20 @@ _gaq.push(['_trackPageview']);
 <?php } ?>
 </head>
 <body class="<?= $this->escape($this->body_class) ?>">
-<div class="navbar sticky-top navbar-expand-lg bg-body-secondary">
+<nav class="navbar sticky-top navbar-expand-lg bg-body-secondary">
     <div class="container-fluid">
         <a class="navbar-brand" href="/">Slack archive</a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarToggle" aria-controls="navbarToggle" aria-expanded="false" aria-label="Navigation">
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarToggle" aria-controls="navbarToggle" aria-expanded="false" aria-label="Menu">
               <span class="navbar-toggler-icon"></span>
         </button>
         <div class="collapse navbar-collapse" id="navbarToggle">
             <ul class="navbar-nav me-auto">
                 <li class="nav-item">
-                    <a class="nav-link" href="https://github.com/ronnywang/g0v-slack-archive"><i class="bi bi-github" aria-hidden></i><span class="ms-2 d-md-none">Source Code</span></a>
+                    <a class="nav-link" href="https://github.com/ronnywang/g0v-slack-archive"><i class="bi bi-github" aria-hidden="true"></i><span class="ms-2 d-md-none">Source Code</span></a>
                 </li>
                 <?php if ($this->user) { ?>
                 <li class="nav-item dropdown">
-                    <button class="btn dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"><i class="bi bi-person-check-fill" aria-hidden></i><span class="ms-2 d-md-none">Authenticated</span></button>
+                    <a class="nav-link dropdown-toggle" data-bs-toggle="dropdown" role="button" aria-expanded="false"><i class="bi bi-person-check-fill" aria-hidden="true"></i><span class="ms-2 d-md-none">Authenticated</span></a>
                     <ul class="dropdown-menu">
                         <li><h6 class="dropdown-header">Hi <?= $this->escape($this->user->name) ?>!</h6></li>
                         <li><a class="dropdown-item" href="/index/logout">Logout</a></li>
@@ -57,15 +57,16 @@ _gaq.push(['_trackPageview']);
                 </li>
                 <?php } else { ?>
                 <li class="nav-item">
-                    <a class="nav-link" href="/index/login/"><i class="bi bi-slack me-2" aria-hidden></i>Login with Slack</a>
+                    <a class="nav-link" href="/index/login/"><i class="bi bi-slack me-2" aria-hidden="true"></i>Login with Slack</a>
                 </li>
                 <?php } ?>
             </ul>
             <form class="d-flex" role="search" method="get" action="/index/search">
                 <input class="form-control me-2" type="search" name="q" placeholder="Search">
+                <button type="submit" class="btn btn-light" aria-label="Search"><i class="bi bi-search" aria-hidden="true"></i></button>
             </form>
         </div>
     </div>
-</div>
-<div class="container-fluid">
+</nav>
+<main class="container-fluid">
     <div class="row-fluid">

--- a/webdata/views/direct/channel.phtml
+++ b/webdata/views/direct/channel.phtml
@@ -1,22 +1,22 @@
 <?php
 
 $this->title = $this->channel->getName($this->user);
-$this->messages = DirectMessage::search(array('channel_id' => $this->channel->id));
+$this->messages = DirectMessage::search(['channel_id' => $this->channel->id]);
 
 $timezoom_offset = date('Z');
 $sql = "SELECT FLOOR((ts + {$timezoom_offset}) / 86400), COUNT(*) FROM direct_message WHERE channel_id = '{$this->channel->id}' GROUP BY FLOOR((ts + {$timezoom_offset}) / 86400)";
 $res = DirectMessage::getDb()->query($sql);
 
-$year_month_count = array();
+$year_month_count = [];
 while ($row = $res->fetch_array()) {
-    list($t, $count) = $row;
+    [$t, $count] = $row;
     $t = $t * 86400 + $timezoom_offset;
 
     $year = date('Y', $t);
     $month = date('Y-m', $t);
 
     if (!array_key_exists($year, $year_month_count)) {
-        $year_month_count[$year] = array();
+        $year_month_count[$year] = [];
     }
 
     if (!array_key_exists($month, $year_month_count[$year])) {
@@ -38,15 +38,15 @@ if ($this->next_date) {
 }
 $thread_tss = $this->messages->search($range_term)->toArray('ts');
 if ($thread_tss) {
-    $reply_threads = DirectMessage::search(array('channel_id' => $this->channel->id))->search("(data->>'thread_ts')::NUMERIC IN (" . implode(',', $thread_tss) . ")");
-    $reply_messages = array();
+    $reply_threads = DirectMessage::search(['channel_id' => $this->channel->id])->search("(data->>'thread_ts')::NUMERIC IN (" . implode(',', $thread_tss) . ")");
+    $reply_messages = [];
     foreach ($reply_threads as $reply) {
         $data = json_decode($reply->data);
         if ($data->thread_ts == $reply->ts) {
             continue;
         }
         if (!array_key_exists($data->thread_ts, $reply_messages)) {
-            $reply_messages[$data->thread_ts] = array();
+            $reply_messages[$data->thread_ts] = [];
         }
         $reply_messages[floatval($data->thread_ts)][$reply->ts] = $reply;
     }
@@ -87,32 +87,34 @@ if ($thread_tss) {
 
 <nav role="pagination">
     <ul class="nav nav-tabs">
-        <?php foreach ($year_month_count as $year => $month_count) { ?>
+    <?php foreach ($year_month_count as $year => $month_count) { ?>
         <li class="nav-item">
-            <?php if (date('Y', $this->current_date) == $year) { ?>
-            <?php $this_month = date('Y-m', $this->current_date) ?>
+        <?php if (date('Y', $this->current_date) == $year) {
+            $this_month = date('Y-m', $this->current_date) ?>
             <a class="nav-link active dropdown-toggle" data-bs-toggle="dropdown" role="button" aria-expanded="false" href="/direct/channel/<?= $this->channel->id ?>/<?= $this_month ?>" aria-label="<?= $year ?>"><?= $this_month ?></a>
-            <?php } else { ?>
+        <?php } else { ?>
             <a class="nav-link dropdown-toggle" data-bs-toggle="dropdown" role="button" aria-expanded="false" href="/direct/channel/<?= $this->channel->id ?>/<?= array_key_first($month_count) ?>"><?= $year ?></a>
-            <?php } ?>
+        <?php } ?>
             <ul class="dropdown-menu">
-                <?php foreach ($month_count as $month => $count) { ?>
+            <?php foreach ($month_count as $month => $count) { ?>
                 <li><a class="dropdown-item" href="/direct/channel/<?= $this->channel->id ?>/<?= $month ?>"><?= $month ?><span class="badge rounded-pill text-primary bg-primary-subtle ms-1" aria-label="<?= $count ?> messages"><?= $count ?></span></a></li>
-                <?php } ?>
+            <?php } ?>
             </ul>
         </li>
+    <?php } ?>
     </ul>
 </nav>
 
 <section role="feed">
-    <?php $current_date = null; ?>
-    <?php foreach ($this->messages->search($range_term)->order('ts ASC') as $message) { ?>
-    <?php if (is_null($current_date) or date('Y-m-d', $message->ts) != $current_date) { ?>
-        <?php $current_date = date('Y-m-d', $message->ts) ?>
+<?php
+$current_date = null;
+foreach ($this->messages->search($range_term)->order('ts ASC') as $message) {
+    if ($current_date === null or date('Y-m-d', $message->ts) != $current_date) {
+        $current_date = date('Y-m-d', $message->ts); ?>
         <h5 class="my-3"><?= $current_date ?></h5>
     <?php } ?>
-    <?= $this->partial('/index/message.phtml', array('message' => $message, 'replies' => $reply_messages[floatval($message->ts)])) ?>
-    <?php } ?>
+    <?= $this->partial('/index/message.phtml', ['message' => $message, 'replies' => $reply_messages[floatval($message->ts)]]) ?>
+<?php } ?>
 </section>
 
 </div>

--- a/webdata/views/direct/channel.phtml
+++ b/webdata/views/direct/channel.phtml
@@ -6,17 +6,30 @@ $this->messages = DirectMessage::search(array('channel_id' => $this->channel->id
 $timezoom_offset = date('Z');
 $sql = "SELECT FLOOR((ts + {$timezoom_offset}) / 86400), COUNT(*) FROM direct_message WHERE channel_id = '{$this->channel->id}' GROUP BY FLOOR((ts + {$timezoom_offset}) / 86400)";
 $res = DirectMessage::getDb()->query($sql);
-$month_count = array();
+
+$year_month_count = array();
 while ($row = $res->fetch_array()) {
     list($t, $count) = $row;
     $t = $t * 86400 + $timezoom_offset;
+
+    $year = date('Y', $t);
     $month = date('Y-m', $t);
-    if (!array_key_exists($month, $month_count)) {
-        $month_count[$month] = 0;
+
+    if (!array_key_exists($year, $year_month_count)) {
+        $year_month_count[$year] = array();
     }
-    $month_count[$month] += $count;
+
+    if (!array_key_exists($month, $year_month_count[$year])) {
+        $year_month_count[$year][$month] = 0;
+    }
+
+    $year_month_count[$year][$month] += $count;
 }
-ksort($month_count);
+
+ksort($year_month_count);
+foreach ($year_month_count as $year => &$month_count) {
+    ksort($month_count);
+}
 
 if ($this->next_date) {
     $range_term = "ts >= {$this->current_date} AND ts < {$this->next_date}";
@@ -40,42 +53,68 @@ if ($thread_tss) {
 }
 ?>
 <?= $this->partial('common/header.phtml', $this) ?>
+
 <style>
-.message .avatar {
-    float: left;
-    padding-right: 5px;
+.badge .emoji {
+    font-size: 16px;
 }
 
-.message .content {
-    overflow: hidden;
-    padding-bottom: 10px;
+.badge .emoji > img {
+    aspect-ratio: auto;
+    max-width: 16px;
+    max-height: 16px;
 }
 
-.message {
-    clear: both;
+.attachment-image {
+    aspect-ratio: auto;
+}
+
+@media screen and (min-width: 48rem) {
+    .attachment-image {
+        max-width: 24rem;
+        max-height: 24rem;
+    }
+}
+
+.message.thread-message {
+    display: none;
 }
 </style>
-<h1><?= $this->escape($this->channel->getName($this->user)) ?></h1>
-<h3>Month: <?= date('Y-m', $this->current_date) ?></h3>
-<div class="pagination">
-    <ul>
-    <?php foreach ($month_count as $month => $count) { ?>
-    <li <?= (date('Y-m', $this->current_date) == $month) ? ' class="active"': ''?>>
-    <a href="/direct/channel/<?= $this->channel->id ?>/<?= $month ?>"><?= $month ?>
-        (<?= $count ?>)
-    </a>
-    </li>
-    <?php } ?>
-</ul>
-</div>
-<?php $current_date = null; ?>
-<?php foreach ($this->messages->search($range_term)->order('ts ASC') as $message) { ?>
-<?php if (is_null($current_date) or date('Y-m-d', $message->ts) != $current_date) { ?>
-<?php $current_date = date('Y-m-d', $message->ts) ?>
-<h4><?= $current_date ?></h4>
-<?php } ?>
-<?= $this->partial('/index/message.phtml', array('message' => $message, 'replies' => $reply_messages[floatval($message->ts)])) ?>
-<div style="clear:both"></div>
-<?php } ?>
-<?= $this->partial('common/footer.phtml', $this) ?>
 
+<div class="container my-4">
+
+<h2><?= $this->escape($this->channel->getName($this->user)) ?></h2>
+
+<nav role="pagination">
+    <ul class="nav nav-tabs">
+        <?php foreach ($year_month_count as $year => $month_count) { ?>
+        <li class="nav-item">
+            <?php if (date('Y', $this->current_date) == $year) { ?>
+            <?php $this_month = date('Y-m', $this->current_date) ?>
+            <a class="nav-link active dropdown-toggle" data-bs-toggle="dropdown" role="button" aria-expanded="false" href="/direct/channel/<?= $this->channel->id ?>/<?= $this_month ?>" aria-label="<?= $year ?>"><?= $this_month ?></a>
+            <?php } else { ?>
+            <a class="nav-link dropdown-toggle" data-bs-toggle="dropdown" role="button" aria-expanded="false" href="/direct/channel/<?= $this->channel->id ?>/<?= array_key_first($month_count) ?>"><?= $year ?></a>
+            <?php } ?>
+            <ul class="dropdown-menu">
+                <?php foreach ($month_count as $month => $count) { ?>
+                <li><a class="dropdown-item" href="/direct/channel/<?= $this->channel->id ?>/<?= $month ?>"><?= $month ?><span class="badge rounded-pill text-primary bg-primary-subtle ms-1" aria-label="<?= $count ?> messages"><?= $count ?></span></a></li>
+                <?php } ?>
+            </ul>
+        </li>
+    </ul>
+</nav>
+
+<section role="feed">
+    <?php $current_date = null; ?>
+    <?php foreach ($this->messages->search($range_term)->order('ts ASC') as $message) { ?>
+    <?php if (is_null($current_date) or date('Y-m-d', $message->ts) != $current_date) { ?>
+        <?php $current_date = date('Y-m-d', $message->ts) ?>
+        <h5 class="my-3"><?= $current_date ?></h5>
+    <?php } ?>
+    <?= $this->partial('/index/message.phtml', array('message' => $message, 'replies' => $reply_messages[floatval($message->ts)])) ?>
+    <?php } ?>
+</section>
+
+</div>
+
+<?= $this->partial('common/footer.phtml', $this) ?>

--- a/webdata/views/direct/index.phtml
+++ b/webdata/views/direct/index.phtml
@@ -1,19 +1,19 @@
 <?php
-$channel_ids = DirectChannelUser::search(array('user_id' => $this->user->id))->toArray('channel_id');
+$channel_ids = DirectChannelUser::search(['user_id' => $this->user->id])->toArray('channel_id');
+
 $sql = "SELECT channel_id, count(*), max(ts) FROM direct_message WHERE channel_id IN ('" . implode('\',\'', $channel_ids) . "') GROUP BY channel_id";
 $res = Message::getDb()->query($sql);
-$channel_count = array();
+$channel_count = [];
 while ($row = $res->fetch_array()) {
-    $channel_count[$row[0]] = array($row[1], $row[2]);
+    $channel_count[$row[0]] = [$row[1], $row[2]];
 }
 
-$channels = array();
+$channels = [];
 foreach (DirectChannel::search(1)->searchIn('id', $channel_ids)  as $channel) {
     $channels[] = $channel;
 }
-usort($channels, function($a, $b) use ($channel_count) {
-    return $channel_count[$b->id][1] - $channel_count[$a->id][1];
-});
+usort($channels, fn($a, $b) => ($channel_count[$b->id][1] - $channel_count[$a->id][1]));
+
 $duser = DirectUser::find($this->user->id);
 $data = json_decode($duser->data);
 ?>
@@ -58,11 +58,11 @@ $data = json_decode($duser->data);
         </tr>
     </thead>
     <tbody>
-        <?php foreach ($channels as $channel) { ?>
-        <?php $data = json_decode($channel->data) ?>
+    <?php foreach ($channels as $channel) {
+        $data = json_decode($channel->data) ?>
         <tr>
             <th scope="row">
-                <a class="channel" href="/direct/channel/<?= $channel->id ?>" title="<?= $this->escape(($channel->data)) ?>"><?= $channel->getName($this->user) ?></a>
+                <a class="channel" href="/direct/channel/<?= $channel->id ?>" title="<?= $this->escape($channel->data) ?>"><?= $channel->getName($this->user) ?></a>
             </th>
             <td><?= date('Y/m/d H:i:s', $data->created) ?></td>
             <td class="text-end"><?= $channel_count[$channel->id][0] ?></td>
@@ -81,7 +81,7 @@ $data = json_decode($duser->data);
                 <?php } ?>
             </td>
         </tr>
-        <?php } ?>
+    <?php } ?>
     </tbody>
 </table>
 </section>
@@ -98,5 +98,4 @@ if (document.location.href.match(/autonext=1/)) {
     $('#update-all').click();
 }
 </script>
-
 <?= $this->partial('common/footer.phtml', $this) ?>

--- a/webdata/views/direct/index.phtml
+++ b/webdata/views/direct/index.phtml
@@ -20,8 +20,17 @@ $data = json_decode($duser->data);
 <?= $this->partial('common/header.phtml', $this) ?>
 
 <style>
-.message a {
+.table thead.position-sticky {
+    top: 3.5rem;
+}
+
+.table th[scope="row"] {
+    max-width: 12em;
+}
+
+.message a, .channel {
     word-break: break-word;
+    text-wrap: balance;
 }
 </style>
 
@@ -31,7 +40,7 @@ $data = json_decode($duser->data);
         <div class="d-flex align-items-baseline">
             <h2 class="h4 text-body-emphasis me-4">Public Channels</h2>
             <?php if (!$data->fetch_link_at) { ?>
-            <a href="/direct/reloadlink" class="btn btn-outline-primary"><i class="bi bi-arrow-repeat me-1" aria-hidden="true"></i>更新列表</a>
+            <a class="btn btn-outline-primary" href="/direct/reloadlink" role="button"><i class="bi bi-arrow-repeat me-1" aria-hidden="true"></i>更新列表</a>
             <?php } ?>
         </div>
     </caption>
@@ -42,9 +51,9 @@ $data = json_decode($duser->data);
             <th scope="col">Messages</th>
             <th scope="col">Members</th>
             <th scope="col">Last Posted</th>
+            <th scope="col">Last Synced</th>
             <th scope="col">
-                Last Synced
-                <a class="btn btn-primary" id="update-all">Update All</a>
+                <button class="btn btn-primary btn-sm" id="update-all" title="Update All"><i class="bi bi-fast-forward" aria-hidden="true"></i></button>
             </th>
         </tr>
     </thead>
@@ -56,8 +65,8 @@ $data = json_decode($duser->data);
                 <a class="channel" href="/direct/channel/<?= $channel->id ?>" title="<?= $this->escape(($channel->data)) ?>"><?= $channel->getName($this->user) ?></a>
             </th>
             <td><?= date('Y/m/d H:i:s', $data->created) ?></td>
-            <td><?= $channel_count[$channel->id][0] ?></td>
-            <td><?= $data->num_members ?></td>
+            <td class="text-end"><?= $channel_count[$channel->id][0] ?></td>
+            <td class="text-end"><?= $data->num_members ?></td>
             <td><?= date('Y/m/d H:i:s', $channel_count[$channel->id][1])?></td>
             <td>
                 <?php if ($channel->last_fetched_at) { ?>
@@ -65,8 +74,10 @@ $data = json_decode($duser->data);
                 <?php } else { ?>
                     not yet
                 <?php } ?>
+            </td>
+            <td>
                 <?php if ($channel->last_fetched_at < time() - 7 * 86400) { ?>
-                    <a href="/direct/update?id=<?= $channel->id ?>" class="btn-primary btn reload-link">Update</a>
+                    <a class="btn btn-outline-secondary btn-sm reload-link" href="/direct/update?id=<?= $channel->id ?>" role="button" title="Update"><i class="bi bi-arrow-clockwise" aria-hidden="true"></i></a>
                 <?php } ?>
             </td>
         </tr>

--- a/webdata/views/direct/index.phtml
+++ b/webdata/views/direct/index.phtml
@@ -7,7 +7,7 @@ while ($row = $res->fetch_array()) {
     $channel_count[$row[0]] = array($row[1], $row[2]);
 }
 
-$channels = array(); 
+$channels = array();
 foreach (DirectChannel::search(1)->searchIn('id', $channel_ids)  as $channel) {
     $channels[] = $channel;
 }
@@ -18,53 +18,63 @@ $duser = DirectUser::find($this->user->id);
 $data = json_decode($duser->data);
 ?>
 <?= $this->partial('common/header.phtml', $this) ?>
-<h1>Direct Messages</h1>
+
 <style>
 .message a {
     word-break: break-word;
 }
 </style>
-<?php if (!$data->fetch_link_at) { ?>
-<a href="/direct/reloadlink" class="btn btn-primary">更新列表</a>
-<?php } ?>
-<table class="table">
-    <thead>
+
+<section class="table-responsive-lg">
+<table class="table table-hover caption-top">
+    <caption>
+        <div class="d-flex align-items-baseline">
+            <h2 class="h4 text-body-emphasis me-4">Public Channels</h2>
+            <?php if (!$data->fetch_link_at) { ?>
+            <a href="/direct/reloadlink" class="btn btn-outline-primary"><i class="bi bi-arrow-repeat me-1" aria-hidden="true"></i>更新列表</a>
+            <?php } ?>
+        </div>
+    </caption>
+    <thead class="position-sticky">
         <tr>
-            <th>Channel</th>
-            <th>Created</th>
-            <th>Message count</th>
-            <th>Members</th>
-            <th>Latest posted</th>
-            <th>
-                Latest synced
+            <th scope="col">Channel</th>
+            <th scope="col">Created</th>
+            <th scope="col">Messages</th>
+            <th scope="col">Members</th>
+            <th scope="col">Last Posted</th>
+            <th scope="col">
+                Last Synced
                 <a class="btn btn-primary" id="update-all">Update All</a>
             </th>
         </tr>
     </thead>
     <tbody>
-    <?php foreach ($channels as $channel) { ?>
-    <?php $data = json_decode($channel->data) ?>
-    <tr>
-        <td>
-            <a href="/direct/channel/<?= $channel->id ?>" title="<?= $this->escape(($channel->data)) ?>"><?= $channel->getName($this->user) ?></a>
-        </td>
-        <td> <?= date('Y/m/d H:i:s', $data->created) ?> </td>
-        <td><?= $channel_count[$channel->id][0] ?></td>
-        <td><?= $data->num_members ?></td>
-        <td><?= date('Y/m/d H:i:s', $channel_count[$channel->id][1])?></td>
-        <td>
-            <?php if ($channel->last_fetched_at) { ?>
-            <?= date('Y/m/d H:i:s', $channel->last_fetched_at) ?>
-            <?php } else { ?>
-            not yet
-            <?php } ?>
-            <?php if ($channel->last_fetched_at < time() - 7 * 86400) { ?>
-            <a href="/direct/update?id=<?= $channel->id ?>" class="btn-primary btn reload-link">Update</a>
-            <?php } ?>
-        </td>
-    <?php } ?>
+        <?php foreach ($channels as $channel) { ?>
+        <?php $data = json_decode($channel->data) ?>
+        <tr>
+            <th scope="row">
+                <a class="channel" href="/direct/channel/<?= $channel->id ?>" title="<?= $this->escape(($channel->data)) ?>"><?= $channel->getName($this->user) ?></a>
+            </th>
+            <td><?= date('Y/m/d H:i:s', $data->created) ?></td>
+            <td><?= $channel_count[$channel->id][0] ?></td>
+            <td><?= $data->num_members ?></td>
+            <td><?= date('Y/m/d H:i:s', $channel_count[$channel->id][1])?></td>
+            <td>
+                <?php if ($channel->last_fetched_at) { ?>
+                    <?= date('Y/m/d H:i:s', $channel->last_fetched_at) ?>
+                <?php } else { ?>
+                    not yet
+                <?php } ?>
+                <?php if ($channel->last_fetched_at < time() - 7 * 86400) { ?>
+                    <a href="/direct/update?id=<?= $channel->id ?>" class="btn-primary btn reload-link">Update</a>
+                <?php } ?>
+            </td>
+        </tr>
+        <?php } ?>
     </tbody>
-</ul>
+</table>
+</section>
+
 <script>
 $('#update-all').click(function(){
     if (!$('.reload-link').length) {
@@ -77,4 +87,5 @@ if (document.location.href.match(/autonext=1/)) {
     $('#update-all').click();
 }
 </script>
+
 <?= $this->partial('common/footer.phtml', $this) ?>

--- a/webdata/views/index/channel.phtml
+++ b/webdata/views/index/channel.phtml
@@ -75,6 +75,10 @@ if ($thread_tss) {
         max-height: 24rem;
     }
 }
+
+.message.thread-message {
+    display: none;
+}
 </style>
 
 <div class="container my-4">

--- a/webdata/views/index/channel.phtml
+++ b/webdata/views/index/channel.phtml
@@ -42,9 +42,14 @@ if ($thread_tss) {
 <?= $this->partial('common/header.phtml', $this) ?>
 
 <style>
-.emoji {
+.badge .emoji {
     font-size: 16px;
-    vertical-align: middle;
+}
+
+.badge .emoji > img {
+    aspect-ratio: auto;
+    max-width: 16px;
+    max-height: 16px;
 }
 
 .attachment-image {

--- a/webdata/views/index/channel.phtml
+++ b/webdata/views/index/channel.phtml
@@ -115,4 +115,6 @@ if ($thread_tss) {
     <?php } ?>
 </section>
 
+</div>
+
 <?= $this->partial('common/footer.phtml', $this) ?>

--- a/webdata/views/index/channel.phtml
+++ b/webdata/views/index/channel.phtml
@@ -40,25 +40,31 @@ if ($thread_tss) {
 }
 ?>
 <?= $this->partial('common/header.phtml', $this) ?>
+
 <style>
-.message .avatar {
-    float: left;
-    padding-right: 5px;
+.emoji {
+    font-size: 16px;
+    vertical-align: middle;
 }
 
-.message .content {
-    overflow: hidden;
-    padding-bottom: 10px;
+.attachment-image {
+    aspect-ratio: auto;
 }
 
-.message {
-    clear: both;
+@media screen and (min-width: 48rem) {
+    .attachment-image {
+        max-width: 24rem;
+        max-height: 24rem;
+    }
 }
 </style>
-<h1><?= $this->escape($this->channel->name) ?></h1>
-<h3>Month: <?= date('Y-m', $this->current_date) ?></h3>
-<div class="pagination">
-    <ul>
+
+<div class="container my-4">
+
+<h2><?php if ($this->channel->is_channel) { ?>#<?php } elseif ($this->channel->is_group) { ?><i class="bi bi-lock-fill me-1" aria-hidden="true"></i><?php } ?><?= $this->escape($this->channel->name) ?></h2>
+
+<nav>
+    <ul class="pagination">
     <?php foreach ($month_count as $month => $count) { ?>
     <li <?= (date('Y-m', $this->current_date) == $month) ? ' class="active"': ''?>>
     <a href="/index/channel/<?= $this->channel->id ?>/<?= $month ?>"><?= $month ?>
@@ -66,16 +72,18 @@ if ($thread_tss) {
     </a>
     </li>
     <?php } ?>
-</ul>
-</div>
-<?php $current_date = null; ?>
-<?php foreach ($this->messages->search($range_term)->order('ts ASC') as $message) { ?>
-<?php if (is_null($current_date) or date('Y-m-d', $message->ts) != $current_date) { ?>
-<?php $current_date = date('Y-m-d', $message->ts) ?>
-<h4><?= $current_date ?></h4>
-<?php } ?>
-<?= $this->partial('/index/message.phtml', array('message' => $message, 'replies' => $reply_messages[floatval($message->ts)])) ?>
-<div style="clear:both"></div>
-<?php } ?>
-<?= $this->partial('common/footer.phtml', $this) ?>
+    </ul>
+</nav>
 
+<section role="feed">
+    <?php $current_date = null; ?>
+    <?php foreach ($this->messages->search($range_term)->order('ts ASC') as $message) { ?>
+    <?php if (is_null($current_date) or date('Y-m-d', $message->ts) != $current_date) { ?>
+        <?php $current_date = date('Y-m-d', $message->ts) ?>
+        <h5 class="my-3"><?= $current_date ?></h5>
+    <?php } ?>
+    <?= $this->partial('/index/message.phtml', array('message' => $message, 'replies' => $reply_messages[floatval($message->ts)])) ?>
+    <?php } ?>
+</section>
+
+<?= $this->partial('common/footer.phtml', $this) ?>

--- a/webdata/views/index/channel.phtml
+++ b/webdata/views/index/channel.phtml
@@ -6,17 +6,30 @@ $this->messages = Message::search(array('channel_id' => $this->channel->id));
 $timezoom_offset = date('Z');
 $sql = "SELECT FLOOR((ts + {$timezoom_offset}) / 86400), COUNT(*) FROM message WHERE channel_id = '{$this->channel->id}' GROUP BY FLOOR((ts + {$timezoom_offset}) / 86400)";
 $res = Message::getDb()->query($sql);
-$month_count = array();
+
+$year_month_count = array();
 while ($row = $res->fetch_array()) {
     list($t, $count) = $row;
     $t = $t * 86400 + $timezoom_offset;
+
+    $year = date('Y', $t);
     $month = date('Y-m', $t);
-    if (!array_key_exists($month, $month_count)) {
-        $month_count[$month] = 0;
+
+    if (!array_key_exists($year, $year_month_count)) {
+        $year_month_count[$year] = array();
     }
-    $month_count[$month] += $count;
+
+    if (!array_key_exists($month, $year_month_count[$year])) {
+        $year_month_count[$year][$month] = 0;
+    }
+
+    $year_month_count[$year][$month] += $count;
 }
-ksort($month_count);
+
+ksort($year_month_count);
+foreach ($year_month_count as $year => &$month_count) {
+    ksort($month_count);
+}
 
 if ($this->next_date) {
     $range_term = "ts >= {$this->current_date} AND ts < {$this->next_date}";
@@ -68,15 +81,22 @@ if ($thread_tss) {
 
 <h2><?php if ($this->channel->is_channel) { ?>#<?php } elseif ($this->channel->is_group) { ?><i class="bi bi-lock-fill me-1" aria-hidden="true"></i><?php } ?><?= $this->escape($this->channel->name) ?></h2>
 
-<nav>
-    <ul class="pagination">
-    <?php foreach ($month_count as $month => $count) { ?>
-    <li <?= (date('Y-m', $this->current_date) == $month) ? ' class="active"': ''?>>
-    <a href="/index/channel/<?= $this->channel->id ?>/<?= $month ?>"><?= $month ?>
-        (<?= $count ?>)
-    </a>
-    </li>
-    <?php } ?>
+<nav role="pagination">
+    <ul class="nav nav-tabs">
+        <?php foreach ($year_month_count as $year => $month_count) { ?>
+        <li class="nav-item">
+            <?php if (date('Y', $this->current_date) == $year) { ?>
+            <?php $this_month = date('Y-m', $this->current_date) ?>
+            <a class="nav-link active dropdown-toggle" data-bs-toggle="dropdown" role="button" aria-expanded="false" href="/index/channel/<?= $this->channel->id ?>/<?= $this_month ?>"><?= $this_month ?></a>
+            <?php } else { ?>
+            <a class="nav-link dropdown-toggle" data-bs-toggle="dropdown" role="button" aria-expanded="false" href="/index/channel/<?= $this->channel->id ?>/<?= array_key_first($month_count) ?>"><?= $year ?></a>
+            <?php } ?>
+            <ul class="dropdown-menu">
+                <?php foreach ($month_count as $month => $count) { ?>
+                <li><a class="dropdown-item" href="/index/channel/<?= $this->channel->id ?>/<?= $month ?>"><?= $month ?><span class="badge rounded-pill text-primary bg-primary-subtle ms-1"><?= $count ?></span></a></li>
+                <?php } ?>
+            </ul>
+        </li>
     </ul>
 </nav>
 

--- a/webdata/views/index/channel.phtml
+++ b/webdata/views/index/channel.phtml
@@ -87,13 +87,13 @@ if ($thread_tss) {
         <li class="nav-item">
             <?php if (date('Y', $this->current_date) == $year) { ?>
             <?php $this_month = date('Y-m', $this->current_date) ?>
-            <a class="nav-link active dropdown-toggle" data-bs-toggle="dropdown" role="button" aria-expanded="false" href="/index/channel/<?= $this->channel->id ?>/<?= $this_month ?>"><?= $this_month ?></a>
+            <a class="nav-link active dropdown-toggle" data-bs-toggle="dropdown" role="button" aria-expanded="false" href="/index/channel/<?= $this->channel->id ?>/<?= $this_month ?>" aria-label="<?= $year ?>"><?= $this_month ?></a>
             <?php } else { ?>
             <a class="nav-link dropdown-toggle" data-bs-toggle="dropdown" role="button" aria-expanded="false" href="/index/channel/<?= $this->channel->id ?>/<?= array_key_first($month_count) ?>"><?= $year ?></a>
             <?php } ?>
             <ul class="dropdown-menu">
                 <?php foreach ($month_count as $month => $count) { ?>
-                <li><a class="dropdown-item" href="/index/channel/<?= $this->channel->id ?>/<?= $month ?>"><?= $month ?><span class="badge rounded-pill text-primary bg-primary-subtle ms-1"><?= $count ?></span></a></li>
+                <li><a class="dropdown-item" href="/index/channel/<?= $this->channel->id ?>/<?= $month ?>"><?= $month ?><span class="badge rounded-pill text-primary bg-primary-subtle ms-1" aria-label="<?= $count ?> messages"><?= $count ?></span></a></li>
                 <?php } ?>
             </ul>
         </li>

--- a/webdata/views/index/channel.phtml
+++ b/webdata/views/index/channel.phtml
@@ -1,22 +1,23 @@
 <?php
 
-$this->title = "#{$this->channel->name}";
-$this->messages = Message::search(array('channel_id' => $this->channel->id));
+$this->data = json_decode($this->channel->data);
+$this->title = $this->data->is_channel ? ("#" . $this->channel->name) : $this->channel->name;
+$this->messages = Message::search(['channel_id' => $this->channel->id]);
 
 $timezoom_offset = date('Z');
 $sql = "SELECT FLOOR((ts + {$timezoom_offset}) / 86400), COUNT(*) FROM message WHERE channel_id = '{$this->channel->id}' GROUP BY FLOOR((ts + {$timezoom_offset}) / 86400)";
 $res = Message::getDb()->query($sql);
 
-$year_month_count = array();
+$year_month_count = [];
 while ($row = $res->fetch_array()) {
-    list($t, $count) = $row;
+    [$t, $count] = $row;
     $t = $t * 86400 + $timezoom_offset;
 
     $year = date('Y', $t);
     $month = date('Y-m', $t);
 
     if (!array_key_exists($year, $year_month_count)) {
-        $year_month_count[$year] = array();
+        $year_month_count[$year] = [];
     }
 
     if (!array_key_exists($month, $year_month_count[$year])) {
@@ -38,15 +39,15 @@ if ($this->next_date) {
 }
 $thread_tss = $this->messages->search($range_term)->toArray('ts');
 if ($thread_tss) {
-    $reply_threads = Message::search(array('channel_id' => $this->channel->id))->search("(data->>'thread_ts')::NUMERIC IN (" . implode(',', $thread_tss) . ")");
-    $reply_messages = array();
+    $reply_threads = Message::search(['channel_id' => $this->channel->id])->search("(data->>'thread_ts')::NUMERIC IN (" . implode(',', $thread_tss) . ")");
+    $reply_messages = [];
     foreach ($reply_threads as $reply) {
         $data = json_decode($reply->data);
         if ($data->thread_ts == $reply->ts) {
             continue;
         }
         if (!array_key_exists($data->thread_ts, $reply_messages)) {
-            $reply_messages[$data->thread_ts] = array();
+            $reply_messages[$data->thread_ts] = [];
         }
         $reply_messages[floatval($data->thread_ts)][$reply->ts] = $reply;
     }
@@ -83,36 +84,38 @@ if ($thread_tss) {
 
 <div class="container my-4">
 
-<h2><?php if ($this->channel->is_channel) { ?>#<?php } elseif ($this->channel->is_group) { ?><i class="bi bi-lock-fill me-1" aria-hidden="true"></i><?php } ?><?= $this->escape($this->channel->name) ?></h2>
+<h2><?php if ($this->data->is_channel) { ?>#<?php } elseif ($this->data->is_group) { ?><i class="bi bi-lock-fill me-1" aria-hidden="true"></i><?php } ?><?= $this->escape($this->channel->name) ?></h2>
 
 <nav role="pagination">
     <ul class="nav nav-tabs">
-        <?php foreach ($year_month_count as $year => $month_count) { ?>
+    <?php foreach ($year_month_count as $year => $month_count) { ?>
         <li class="nav-item">
-            <?php if (date('Y', $this->current_date) == $year) { ?>
-            <?php $this_month = date('Y-m', $this->current_date) ?>
+        <?php if (date('Y', $this->current_date) == $year) {
+            $this_month = date('Y-m', $this->current_date) ?>
             <a class="nav-link active dropdown-toggle" data-bs-toggle="dropdown" role="button" aria-expanded="false" href="/index/channel/<?= $this->channel->id ?>/<?= $this_month ?>" aria-label="<?= $year ?>"><?= $this_month ?></a>
-            <?php } else { ?>
+        <?php } else { ?>
             <a class="nav-link dropdown-toggle" data-bs-toggle="dropdown" role="button" aria-expanded="false" href="/index/channel/<?= $this->channel->id ?>/<?= array_key_first($month_count) ?>"><?= $year ?></a>
-            <?php } ?>
+        <?php } ?>
             <ul class="dropdown-menu">
-                <?php foreach ($month_count as $month => $count) { ?>
+            <?php foreach ($month_count as $month => $count) { ?>
                 <li><a class="dropdown-item" href="/index/channel/<?= $this->channel->id ?>/<?= $month ?>"><?= $month ?><span class="badge rounded-pill text-primary bg-primary-subtle ms-1" aria-label="<?= $count ?> messages"><?= $count ?></span></a></li>
-                <?php } ?>
+            <?php } ?>
             </ul>
         </li>
+    <?php } ?>
     </ul>
 </nav>
 
 <section role="feed">
-    <?php $current_date = null; ?>
-    <?php foreach ($this->messages->search($range_term)->order('ts ASC') as $message) { ?>
-    <?php if (is_null($current_date) or date('Y-m-d', $message->ts) != $current_date) { ?>
-        <?php $current_date = date('Y-m-d', $message->ts) ?>
+<?php
+$current_date = null;
+foreach ($this->messages->search($range_term)->order('ts ASC') as $message) {
+    if ($current_date === null or date('Y-m-d', $message->ts) != $current_date) {
+        $current_date = date('Y-m-d', $message->ts); ?>
         <h5 class="my-3"><?= $current_date ?></h5>
     <?php } ?>
-    <?= $this->partial('/index/message.phtml', array('message' => $message, 'replies' => $reply_messages[floatval($message->ts)])) ?>
-    <?php } ?>
+    <?= $this->partial('/index/message.phtml', ['message' => $message, 'replies' => $reply_messages[floatval($message->ts)]]) ?>
+<?php } ?>
 </section>
 
 </div>

--- a/webdata/views/index/index.phtml
+++ b/webdata/views/index/index.phtml
@@ -1,21 +1,16 @@
 <?php
 $sql = "SELECT channel_id, count(*), max(ts) FROM message GROUP BY channel_id";
 $res = Message::getDb()->query($sql);
-$channel_count = array();
+$channel_count = [];
 while ($row = $res->fetch_array()) {
-    $channel_count[$row[0]] = array($row[1], $row[2]);
+    $channel_count[$row[0]] = [$row[1], $row[2]];
 }
-$channels = array();
-foreach (Channel::search(1)  as $channel) {
+
+$channels = [];
+foreach (Channel::search(1) as $channel) {
     $channels[] = $channel;
 }
-usort($channels, function($a, $b) {
-    $dataa = json_decode($a->data);
-    $datab = json_decode($b->data);
-
-    return $datab->num_members - $dataa->num_members;
-
-});
+usort($channels, fn($a, $b) => (json_decode($b->data)->num_members - json_decode($a->data)->num_members));
 ?>
 <?= $this->partial('common/header.phtml', $this) ?>
 
@@ -54,28 +49,22 @@ usort($channels, function($a, $b) {
         </tr>
     </thead>
     <tbody>
-        <?php foreach ($this->private_channel as $private_channel) { ?>
-        <?php if (!$channel = Channel::find($private_channel)) { continue; } ?>
-        <?php $data = json_decode($channel->data) ?>
+    <?php foreach ($this->private_channel as $private_channel) {
+        if (!$channel = Channel::find($private_channel)) { continue; }
+        $data = json_decode($channel->data);
+        $private_config = json_decode($channel->private_config); ?>
         <tr>
             <th scope="row">
-                <a class="channel" href="/index/channel/<?= $channel->id ?>" title="<?= $this->escape(($channel->data)) ?>"><i class="bi bi-lock-fill me-1" aria-hidden="true"></i><?= $channel->name ?></a>
+                <a class="channel" href="/index/channel/<?= $channel->id ?>" title="<?= $this->escape($channel->data) ?>"><i class="bi bi-lock-fill me-1" aria-hidden="true"></i><?= $this->escape($channel->name) ?></a>
             </th>
             <td class="message"><?= Message::getHTML($data->topic->value) ?></td>
             <td class="message"><?= Message::getHTML($data->purpose->value) ?></td>
-            <td><?= date('Y/m/d H:i:s', $data->created) ?> </td>
-        <?php $private_config = json_decode($channel->private_config) ?>
+            <td><?= date('Y/m/d H:i:s', $data->created) ?></td>
         <?php if (property_exists($private_config, 'access_token')) { ?>
             <td class="text-end"><?= $channel_count[$channel->id][0] ?></td>
             <td class="text-end"><?= $data->num_members ?></td>
             <td><?= date('Y/m/d H:i:s', $channel_count[$channel->id][1])?></td>
-            <td>
-                <?php if ($channel->last_fetched_at) { ?>
-                    <?= date('Y/m/d H:i:s', $channel->last_fetched_at) ?>
-                <?php } else { ?>
-                    not yet
-                <?php } ?>
-            </td>
+            <td><?= $channel->last_fetched_at ? date('Y/m/d H:i:s', $channel->last_fetched_at) : 'not yet' ?></td>
             <td>
                 <form method="post" action="/index/addprivatechannel?channel=<?= urlencode($channel->id) ?>">
                     <button class="btn btn-outline-secondary btn-sm" type="submit" title="手動同步"><i class="bi bi-arrow-clockwise" aria-hidden="true"></i></button>
@@ -90,7 +79,7 @@ usort($channels, function($a, $b) {
             </td>
         <?php } ?>
         </tr>
-        <?php } ?>
+    <?php } ?>
     </tbody>
 </table>
 </section>
@@ -114,12 +103,12 @@ usort($channels, function($a, $b) {
         </tr>
     </thead>
     <tbody>
-        <?php foreach ($channels as $channel) { ?>
-        <?php $data = json_decode($channel->data) ?>
-        <?php if (property_exists($data, 'is_private') and $data->is_private) { continue; } ?>
+    <?php foreach ($channels as $channel) {
+        $data = json_decode($channel->data);
+        if (property_exists($data, 'is_private') and $data->is_private) { continue; } ?>
         <tr>
             <th scope="row">
-                <a class="channel" href="/index/channel/<?= $channel->id ?>" title="<?= $this->escape(($channel->data)) ?>">#<?= $channel->name ?></a>
+                <a class="channel" href="/index/channel/<?= $channel->id ?>" title="<?= $this->escape($channel->data) ?>">#<?= $this->escape($channel->name) ?></a>
             </th>
             <td class="message"><?= Message::getHTML($data->topic->value) ?></td>
             <td class="message"><?= Message::getHTML($data->purpose->value) ?></td>
@@ -127,15 +116,9 @@ usort($channels, function($a, $b) {
             <td class="text-end"><?= $channel_count[$channel->id][0] ?></td>
             <td class="text-end"><?= $data->num_members ?></td>
             <td><?= date('Y/m/d H:i:s', $channel_count[$channel->id][1])?></td>
-            <td>
-                <?php if ($channel->last_fetched_at) { ?>
-                    <?= date('Y/m/d H:i:s', $channel->last_fetched_at) ?>
-                <?php } else { ?>
-                    not yet
-                <?php } ?>
-            </td>
+            <td><?= $channel->last_fetched_at ? date('Y/m/d H:i:s', $channel->last_fetched_at) : 'not yet' ?></td>
         </tr>
-        <?php } ?>
+    <?php } ?>
     </tbody>
 </table>
 </section>

--- a/webdata/views/index/index.phtml
+++ b/webdata/views/index/index.phtml
@@ -24,8 +24,13 @@ usort($channels, function($a, $b) {
     top: 3.5rem;
 }
 
-.message a {
+.table th[scope="row"] {
+    max-width: 12em;
+}
+
+.message a, .channel {
     word-break: break-word;
+    text-wrap: balance;
 }
 </style>
 
@@ -39,11 +44,13 @@ usort($channels, function($a, $b) {
         <tr>
             <th scope="col">Channel</th>
             <th scope="col">Topic</th>
+            <th scope="col">Description</th>
             <th scope="col">Created</th>
             <th scope="col">Messages</th>
             <th scope="col">Members</th>
             <th scope="col">Last Posted</th>
             <th scope="col">Last Synced</th>
+            <th scope="col"></th>
         </tr>
     </thead>
     <tbody>
@@ -52,14 +59,15 @@ usort($channels, function($a, $b) {
         <?php $data = json_decode($channel->data) ?>
         <tr>
             <th scope="row">
-                <a class="channel" href="/index/channel/<?= $channel->id ?>" title="<?= $this->escape(($channel->data)) ?>"><?= $channel->name ?></a>
+                <a class="channel" href="/index/channel/<?= $channel->id ?>" title="<?= $this->escape(($channel->data)) ?>"><i class="bi bi-lock-fill me-1" aria-hidden="true"></i><?= $channel->name ?></a>
             </th>
             <td class="message"><?= Message::getHTML($data->topic->value) ?></td>
+            <td class="message"><?= Message::getHTML($data->purpose->value) ?></td>
             <td><?= date('Y/m/d H:i:s', $data->created) ?> </td>
         <?php $private_config = json_decode($channel->private_config) ?>
         <?php if (property_exists($private_config, 'access_token')) { ?>
-            <td><?= $channel_count[$channel->id][0] ?></td>
-            <td><?= $data->num_members ?></td>
+            <td class="text-end"><?= $channel_count[$channel->id][0] ?></td>
+            <td class="text-end"><?= $data->num_members ?></td>
             <td><?= date('Y/m/d H:i:s', $channel_count[$channel->id][1])?></td>
             <td>
                 <?php if ($channel->last_fetched_at) { ?>
@@ -67,14 +75,17 @@ usort($channels, function($a, $b) {
                 <?php } else { ?>
                     not yet
                 <?php } ?>
+            </td>
+            <td>
                 <form method="post" action="/index/addprivatechannel?channel=<?= urlencode($channel->id) ?>">
-                    <button type="submit">手動同步</button>
+                    <button class="btn btn-outline-secondary btn-sm" type="submit" title="手動同步"><i class="bi bi-arrow-clockwise" aria-hidden="true"></i></button>
                 </form>
             </td>
         <?php } else { ?>
-            <td colspan="4">
+            <td colspan="4"></td>
+            <td>
                 <form method="post" action="/index/addprivatechannel?channel=<?= urlencode($channel->id) ?>">
-                    <button type="submit">開始同步</button>
+                    <button class="btn btn-outline-primary btn-sm" type="submit" title="開始同步"><i class="bi bi-cloud-download" aria-hidden="true"></i></button>
                 </form>
             </td>
         <?php } ?>
@@ -108,13 +119,13 @@ usort($channels, function($a, $b) {
         <?php if (property_exists($data, 'is_private') and $data->is_private) { continue; } ?>
         <tr>
             <th scope="row">
-                <a class="channel" href="/index/channel/<?= $channel->id ?>" title="<?= $this->escape(($channel->data)) ?>"><?= $channel->name ?></a>
+                <a class="channel" href="/index/channel/<?= $channel->id ?>" title="<?= $this->escape(($channel->data)) ?>">#<?= $channel->name ?></a>
             </th>
             <td class="message"><?= Message::getHTML($data->topic->value) ?></td>
             <td class="message"><?= Message::getHTML($data->purpose->value) ?></td>
             <td><?= date('Y/m/d H:i:s', $data->created) ?></td>
-            <td><?= $channel_count[$channel->id][0] ?></td>
-            <td><?= $data->num_members ?></td>
+            <td class="text-end"><?= $channel_count[$channel->id][0] ?></td>
+            <td class="text-end"><?= $data->num_members ?></td>
             <td><?= date('Y/m/d H:i:s', $channel_count[$channel->id][1])?></td>
             <td>
                 <?php if ($channel->last_fetched_at) { ?>

--- a/webdata/views/index/index.phtml
+++ b/webdata/views/index/index.phtml
@@ -5,7 +5,7 @@ $channel_count = array();
 while ($row = $res->fetch_array()) {
     $channel_count[$row[0]] = array($row[1], $row[2]);
 }
-$channels = array(); 
+$channels = array();
 foreach (Channel::search(1)  as $channel) {
     $channels[] = $channel;
 }
@@ -18,100 +18,115 @@ usort($channels, function($a, $b) {
 });
 ?>
 <?= $this->partial('common/header.phtml', $this) ?>
-<?php if ($this->private_channel) { ?>
-<h1>Private Channels</h1>
-<table class="table">
-    <thead>
-        <tr>
-            <th>Channel</th>
-            <th>Topic</th>
-            <th>Created</th>
-            <th>Message count</th>
-            <th>Members</th>
-            <th>Latest posted</th>
-            <th>Latest synced</th>
-        </tr>
-    </thead>
-    <tbody>
-    <?php foreach ($this->private_channel as $private_channel) { ?>
-    <?php if (!$channel = Channel::find($private_channel)) { continue; } ?>
-    <?php $data = json_decode($channel->data) ?>
-    <tr>
-        <td>
-            <a href="/index/channel/<?= $channel->id ?>" title="<?= $this->escape(($channel->data)) ?>"><?= $channel->name ?></a>
-        </td>
-        <td><?= Message::getHTML($data->topic->value) ?></td>
-        <td> <?= date('Y/m/d H:i:s', $data->created) ?> </td>
-        <?php $private_config = json_decode($channel->private_config) ?>
-        <?php if (property_exists($private_config, 'access_token')) { ?>
-        <td><?= $channel_count[$channel->id][0] ?></td>
-        <td><?= $data->num_members ?></td>
-        <td><?= date('Y/m/d H:i:s', $channel_count[$channel->id][1])?></td>
-        <td>
-            <?php if ($channel->last_fetched_at) { ?>
-            <?= date('Y/m/d H:i:s', $channel->last_fetched_at) ?>
-            <?php } else { ?>
-            not yet
-            <?php } ?>
-            <form method="post" action="/index/addprivatechannel?channel=<?= urlencode($channel->id) ?>">
-               <button type="submit">手動同步</button>
-            </form>
-        </td>
-        <?php } else { ?>
-        <td colspan="3">
-            <form method="post" action="/index/addprivatechannel?channel=<?= urlencode($channel->id) ?>">
-               <button type="submit">開始同步</button>
-            </form>
-        </td>
-        <?php } ?>
-    </tr>
-    <?php } ?>
-    </tbody>
-</table>
-<?php } ?>
-<h1>Public Channels</h1>
+
 <style>
+.table thead.position-sticky {
+    top: 3.5rem;
+}
+
 .message a {
     word-break: break-word;
 }
 </style>
-<table class="table">
-    <thead>
+
+<?php if ($this->private_channel) { ?>
+<section class="table-responsive-lg">
+<table class="table table-hover caption-top">
+    <caption class="text-body-emphasis">
+        <h2 class="h4">Private Channels</h2>
+    </caption>
+    <thead class="position-sticky">
         <tr>
-            <th>Channel</th>
-            <th>Topic</th>
-            <th>Description</th>
-            <th>Created</th>
-            <th>Message count</th>
-            <th>Members</th>
-            <th>Latest posted</th>
-            <th>Latest synced</th>
+            <th scope="col">Channel</th>
+            <th scope="col">Topic</th>
+            <th scope="col">Created</th>
+            <th scope="col">Messages</th>
+            <th scope="col">Members</th>
+            <th scope="col">Last Posted</th>
+            <th scope="col">Last Synced</th>
         </tr>
     </thead>
     <tbody>
-    <?php foreach ($channels as $channel) { ?>
-    <?php $data = json_decode($channel->data) ?>
-    <?php if (property_exists($data, 'is_private') and $data->is_private) { continue; } ?>
-    <tr>
-        <td>
-            <a href="/index/channel/<?= $channel->id ?>" title="<?= $this->escape(($channel->data)) ?>"><?= $channel->name ?></a>
-        </td>
-        <td class="message"><?= Message::getHTML($data->topic->value) ?></td>
-        <td class="message"><?= Message::getHTML($data->purpose->value) ?></td>
-        <td> <?= date('Y/m/d H:i:s', $data->created) ?> </td>
-        <td><?= $channel_count[$channel->id][0] ?></td>
-        <td><?= $data->num_members ?></td>
-        <td><?= date('Y/m/d H:i:s', $channel_count[$channel->id][1])?></td>
-        <td>
-            <?php if ($channel->last_fetched_at) { ?>
-            <?= date('Y/m/d H:i:s', $channel->last_fetched_at) ?>
-            <?php } else { ?>
-            not yet
-            <?php } ?>
-
-        </td>
-    <?php } ?>
+        <?php foreach ($this->private_channel as $private_channel) { ?>
+        <?php if (!$channel = Channel::find($private_channel)) { continue; } ?>
+        <?php $data = json_decode($channel->data) ?>
+        <tr>
+            <th scope="row">
+                <a class="channel" href="/index/channel/<?= $channel->id ?>" title="<?= $this->escape(($channel->data)) ?>"><?= $channel->name ?></a>
+            </th>
+            <td class="message"><?= Message::getHTML($data->topic->value) ?></td>
+            <td><?= date('Y/m/d H:i:s', $data->created) ?> </td>
+        <?php $private_config = json_decode($channel->private_config) ?>
+        <?php if (property_exists($private_config, 'access_token')) { ?>
+            <td><?= $channel_count[$channel->id][0] ?></td>
+            <td><?= $data->num_members ?></td>
+            <td><?= date('Y/m/d H:i:s', $channel_count[$channel->id][1])?></td>
+            <td>
+                <?php if ($channel->last_fetched_at) { ?>
+                    <?= date('Y/m/d H:i:s', $channel->last_fetched_at) ?>
+                <?php } else { ?>
+                    not yet
+                <?php } ?>
+                <form method="post" action="/index/addprivatechannel?channel=<?= urlencode($channel->id) ?>">
+                    <button type="submit">手動同步</button>
+                </form>
+            </td>
+        <?php } else { ?>
+            <td colspan="4">
+                <form method="post" action="/index/addprivatechannel?channel=<?= urlencode($channel->id) ?>">
+                    <button type="submit">開始同步</button>
+                </form>
+            </td>
+        <?php } ?>
+        </tr>
+        <?php } ?>
     </tbody>
-</ul>
+</table>
+</section>
+<?php } ?>
+
+<section class="table-responsive-lg">
+<table class="table table-hover caption-top">
+    <caption class="text-body-emphasis">
+        <h2 class="h4">Public Channels</h2>
+    </caption>
+    <thead class="position-sticky">
+        <tr>
+            <th scope="col">Channel</th>
+            <th scope="col">Topic</th>
+            <th scope="col">Description</th>
+            <th scope="col">Created</th>
+            <th scope="col">Messages</th>
+            <th scope="col">Members</th>
+            <th scope="col">Last Posted</th>
+            <th scope="col">Last Synced</th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php foreach ($channels as $channel) { ?>
+        <?php $data = json_decode($channel->data) ?>
+        <?php if (property_exists($data, 'is_private') and $data->is_private) { continue; } ?>
+        <tr>
+            <th scope="row">
+                <a class="channel" href="/index/channel/<?= $channel->id ?>" title="<?= $this->escape(($channel->data)) ?>"><?= $channel->name ?></a>
+            </th>
+            <td class="message"><?= Message::getHTML($data->topic->value) ?></td>
+            <td class="message"><?= Message::getHTML($data->purpose->value) ?></td>
+            <td><?= date('Y/m/d H:i:s', $data->created) ?></td>
+            <td><?= $channel_count[$channel->id][0] ?></td>
+            <td><?= $data->num_members ?></td>
+            <td><?= date('Y/m/d H:i:s', $channel_count[$channel->id][1])?></td>
+            <td>
+                <?php if ($channel->last_fetched_at) { ?>
+                    <?= date('Y/m/d H:i:s', $channel->last_fetched_at) ?>
+                <?php } else { ?>
+                    not yet
+                <?php } ?>
+            </td>
+        </tr>
+        <?php } ?>
+    </tbody>
+</table>
+</section>
 
 <?= $this->partial('common/footer.phtml', $this) ?>

--- a/webdata/views/index/login.phtml
+++ b/webdata/views/index/login.phtml
@@ -1,33 +1,47 @@
 <?= $this->partial('/common/header.phtml', $this) ?>
-請選擇您為什麼要登入：
-<ul>
-    <li>
-    我想要協助備份非公開頻道記錄
-    <ul>
-        <li>會需要您提供可以離線瀏覽頻道的權限</li>
-        <li><a href="/index/login?type=backup"><button>登入</button></a></li>
-    </ul>
-    </li>
-    <li>我想要瀏覽非公開頻道記錄
-    <ul>
-        <li>只需要驗證您的身份，不需要您提供權限</li>
-        <li><a href="/index/login?type=read"><button>登入</button></a></li>
-    </ul>
-    </li>
-    <li>
-    我想要備份我個人的私密訊息
-    <ul>
-        <li>會需要您提供可以離線瀏覽私訊的權限(im.read)</li>
-        <li><a href="/index/login?type=im"><button>登入</button></a></li>
-    </ul>
-    </li>
-    <li>
-    我想要瀏覽公開頻道記錄
-    <ul>
-        <li>
-        不需要登入即可使用
-        </li>
-    </ul>
-    </li>
-</ul>
+<section class="container">
+    <h2 class="my-4 py-4 text-center">請選擇您為什麼要登入</h2>
+    <div class="row row-cols-1 row-cols-md-2 row-cols-xl-4 g-4">
+        <div class="col">
+            <div class="card">
+                <div class="card-body">
+                    <div class="card-img-top text-center display-2 pt-2 pb-4 text-primary"><i class="bi bi-cloud-download me-2" aria-hidden="true"></i></div>
+                    <h4 class="card-title">我想要協助備份非公開頻道記錄</h4>
+                    <p class="card-text">會需要您提供可以離線瀏覽頻道的權限。</p>
+                    <a class="btn btn-primary" href="/index/login?type=backup"><i class="bi bi-slack me-1" aria-hidden="true"></i>登入</a>
+                </div>
+            </div>
+        </div>
+        <div class="col">
+            <div class="card">
+                <div class="card-body">
+                    <div class="card-img-top text-center display-2 pt-2 pb-4 text-primary"><i class="bi bi-database me-2" aria-hidden="true"></i></div>
+                    <h4 class="card-title">我想要瀏覽非公開頻道記錄</h4>
+                    <p class="card-text">只需要驗證您的身分，不需要您提供權限。</p>
+                    <a class="btn btn-primary" href="/index/login?type=read"><i class="bi bi-slack me-1" aria-hidden="true"></i>登入</a>
+                </div>
+            </div>
+        </div>
+        <div class="col">
+            <div class="card">
+                <div class="card-body">
+                    <div class="card-img-top text-center display-2 pt-2 pb-4 text-primary"><i class="bi bi-person-lock me-2" aria-hidden="true"></i></div>
+                    <h4 class="card-title">我想要備份我個人的私密訊息</h4>
+                    <p class="card-text">會需要您提供可以離線瀏覽私訊的權限（<code>im.read</code>）。</p>
+                    <a class="btn btn-primary" href="/index/login?type=im"><i class="bi bi-slack me-1" aria-hidden="true"></i>登入</a>
+                </div>
+            </div>
+        </div>
+        <div class="col">
+            <div class="card">
+                <div class="card-body">
+                    <div class="card-img-top text-center display-2 pt-2 pb-4 text-primary"><i class="bi bi-hash me-2" aria-hidden="true"></i></div>
+                    <h4 class="card-title">我想要瀏覽公開頻道記錄</h4>
+                    <p class="card-text">不需要登入即可使用。</p>
+                    <a class="btn btn-light" href="/"><i class="bi bi-arrow-left me-1" aria-hidden="true"></i>回到首頁</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
 <?= $this->partial('/common/footer.phtml', $this) ?>

--- a/webdata/views/index/message.phtml
+++ b/webdata/views/index/message.phtml
@@ -41,6 +41,31 @@ if ($message_data->parent_user_id and !$message_data->is_thread_broadcast) {
         <?php if (property_exists($message_data, 'attachments')) { ?>
         <?php foreach ($message_data->attachments as $attachment) { ?>
         <blockquote class="card my-2" title="<?= $this->escape(json_encode($attachment, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT)) ?>">
+            <?php if ($attachment->is_msg_unfurl) { ?>
+            <?php $embed_message = Message::find(array($attachment->channel_id, $attachment->ts)) ?>
+            <?php $embed_message_data = json_decode($embed_message->data) ?>
+            <?php $embed_channel = Channel::find($attachment->channel_id) ?>
+            <div class="card-body">
+                <h6 class="card-title">
+                    <img class="avatar rounded" src="<?= $attachment->escape($attachment->author_icon) ?>" width="24" height="24">
+                    <span class="user-name"><strong><?= $attachment->escape($attachment->author_name) ?></strong></span>
+                </h6>
+                <div class="card-text">
+                    <?= Message::getHTML($embed_message_data) ?>
+                </div>
+                <ul class="message-meta list-inline my-2 text-secondary small">
+                    <li class="list-inline-item">
+                        Forwarded from
+                        <?php if ($embed_channel->is_channel) { ?>
+                        <a class="channel text-reset" href="/index/channel/<?= $embed_channel->id ?>">#<?= $embed_channel->name ?></a>
+                        <?php } else { ?>
+                        a private channel
+                        <?php } ?>
+                    </li>
+                    <li class="list-inline-item"><a class="message-time text-reset" href="/index/channel/<?= $attachment->channel_id ?>/<?= date('Y-m', $attachment->ts) ?>#ts-<?= $attachment->ts ?>"><?= date('Y-m-d H:i:s', $attachment->ts) ?></a></li>
+                </ul>
+            </div>
+            <?php } else { ?>
             <div class="row g-0">
                 <div class="col">
                     <div class="card-body">
@@ -62,6 +87,7 @@ if ($message_data->parent_user_id and !$message_data->is_thread_broadcast) {
                 </div>
                 <?php } ?>
             </div>
+            <?php } ?>
         </blockquote>
         <?php } ?>
         <?php } ?>
@@ -69,7 +95,7 @@ if ($message_data->parent_user_id and !$message_data->is_thread_broadcast) {
         <?php if (property_exists($message_data, 'reactions')) { ?>
         <ul class="reactions list-inline my-1">
             <?php foreach ($message_data->reactions as $reaction) { ?>
-            <li class="list-inline-item badge rounded-pill text-bg-light"><?= Message::getEmoji($reaction->name) ?> <?= $reaction->count ?></li>
+            <li class="list-inline-item badge rounded-pill text-bg-light"><span class="emoji me-1"><?= Message::getEmoji($reaction->name) ?></span><?= $reaction->count ?></li>
             <?php } ?>
         </ul>
         <?php } ?>

--- a/webdata/views/index/message.phtml
+++ b/webdata/views/index/message.phtml
@@ -45,8 +45,8 @@ if ($message_data->parent_user_id and !$message_data->is_thread_broadcast) {
             <?php $embed_channel = Channel::find($attachment->channel_id) ?>
             <div class="card-body">
                 <h6 class="card-title">
-                    <img class="avatar rounded" src="<?= $attachment->escape($attachment->author_icon) ?>" width="24" height="24">
-                    <span class="user-name"><strong><?= $attachment->escape($attachment->author_name) ?></strong></span>
+                    <img class="avatar rounded" src="<?= $this->escape($attachment->author_icon) ?>" width="24" height="24">
+                    <span class="user-name"><strong><?= $this->escape($attachment->author_name) ?></strong></span>
                 </h6>
                 <div class="card-text">
                     <?= Message::getHTML($embed_message_data) ?>
@@ -55,7 +55,7 @@ if ($message_data->parent_user_id and !$message_data->is_thread_broadcast) {
                     <li class="list-inline-item">
                         Forwarded from
                         <?php if ($embed_channel->is_channel) { ?>
-                        <a class="channel text-reset" href="/index/channel/<?= $embed_channel->id ?>">#<?= $embed_channel->name ?></a>
+                        <a class="channel text-reset" href="/index/channel/<?= $embed_channel->id ?>">#<?= $this->escape($embed_channel->name) ?></a>
                         <?php } else { ?>
                         a private channel
                         <?php } ?>

--- a/webdata/views/index/message.phtml
+++ b/webdata/views/index/message.phtml
@@ -17,9 +17,7 @@ if ($message_data->parent_user_id and !$message_data->is_thread_broadcast) {
 }
 ?>
 <div class="message d-flex mb-2" style="<?= $style ?>" id="ts-<?= $this->message->ts?>">
-    <div class="avatar flex-shrink-0">
-        <img class="rounded" src="<?= $this->escape($avatar) ?>" width="36" height="36">
-    </div>
+    <img class="avatar flex-shrink-0 rounded" src="<?= $this->escape($avatar) ?>" width="36" height="36">
     <div class="flex-grow-1 ms-2">
         <div class="meta">
             <span class="user-name" title="<?= htmlspecialchars(json_encode($user_data, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT)) ?>"><strong><?= $this->escape(Message::getUserName($message_data->user)) ?></strong></span>
@@ -111,9 +109,7 @@ if ($message_data->parent_user_id and !$message_data->is_thread_broadcast) {
                 <?php $reply_user_data = new stdClass; ?>
             <?php } ?>
             <div class="message d-flex mb-2" id="ts-<?= $reply_message->ts?>">
-                <div class="avatar flex-shrink-0">
-                    <img src="<?= $this->escape($reply_user_data->profile->image_72) ?>" width="24" height="24">
-                </div>
+                <img class="avatar flex-shrink-0 rounded" src="<?= $this->escape($reply_user_data->profile->image_72) ?>" width="24" height="24">
                 <div class="flex-grow-1 ms-2">
                     <div class="meta">
                         <span class="user-name" title="<?= htmlspecialchars(json_encode($reply_user_data, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT)) ?>"><strong><?= $this->escape(Message::getUserName($reply_message_data->user)) ?></strong></span>

--- a/webdata/views/index/message.phtml
+++ b/webdata/views/index/message.phtml
@@ -24,32 +24,31 @@ if ($message_data->parent_user_id and !$message_data->is_thread_broadcast) {
             <span class="message-time small" title="<?= htmlspecialchars(json_encode($message_data, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT)) ?>"><a class="link-secondary link-underline link-underline-opacity-0 link-underline-opacity-75-hover" href="#ts-<?= $this->message->ts ?>"><?= date('H:i:s', $this->message->ts) ?></a></span>
         </div>
 
-        <?php if($message_data->subtype == "thread_broadcast" and property_exists($message_data, 'root')) { ?>
+    <?php if($message_data->subtype == "thread_broadcast" and property_exists($message_data, 'root')) { ?>
         <div class="thread-root">
             Replied to a thread: <a class="link-underline link-underline-opacity-0 link-underline-opacity-75-hover" href="/index/channel/<?= $this->message->channel_id ?>/<?= date('Y-m', $message_data->thread_ts) ?>#ts-<?= $message_data->thread_ts ?>"><?= date('Y-m-d H:i:s', $message_data->thread_ts) ?></a>
         </div>
-        <?php } ?>
+    <?php } ?>
 
         <div class="contents">
             <?= Message::getHTML($message_data) ?>
         </div>
 
-        <?php if (property_exists($message_data, 'files')) { ?>
-        <?php foreach ($message_data->files as $file) { ?>
+    <?php if (property_exists($message_data, 'files')) {
+        foreach ($message_data->files as $file) { ?>
         <figure class="figure my-2">
             <img class="attachment-image rounded" src="<?= $this->escape("/index/file?url=" . urlencode($file->thumb_360)) ?>">
             <figcaption class="figure-caption"><?= $this->escape($file->title) ?></figcaption>
         </figure>
-        <?php } ?>
-        <?php } ?>
+    <?php }} ?>
 
-        <?php if (property_exists($message_data, 'attachments')) { ?>
-        <?php foreach ($message_data->attachments as $attachment) { ?>
+    <?php if (property_exists($message_data, 'attachments')) {
+        foreach ($message_data->attachments as $attachment) { ?>
         <blockquote class="card my-2" title="<?= $this->escape(json_encode($attachment, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT)) ?>">
-            <?php if ($attachment->is_msg_unfurl) { ?>
-            <?php $embed_message = Message::find(array($attachment->channel_id, $attachment->ts)) ?>
-            <?php $embed_message_data = json_decode($embed_message->data) ?>
-            <?php $embed_channel = Channel::find($attachment->channel_id) ?>
+        <?php if ($attachment->is_msg_unfurl) {
+            $embed_message = Message::find([$attachment->channel_id, $attachment->ts]);
+            $embed_message_data = json_decode($embed_message->data);
+            $embed_channel = Channel::find($attachment->channel_id) ?>
             <div class="card-body">
                 <h6 class="card-title">
                     <img class="avatar rounded" src="<?= $this->escape($attachment->author_icon) ?>" width="24" height="24">
@@ -61,16 +60,16 @@ if ($message_data->parent_user_id and !$message_data->is_thread_broadcast) {
                 <ul class="message-meta list-inline my-2 text-secondary small">
                     <li class="list-inline-item">
                         Forwarded from
-                        <?php if ($embed_channel->is_channel) { ?>
+                    <?php if ($embed_channel->is_channel) { ?>
                         <a class="channel text-reset" href="/index/channel/<?= $embed_channel->id ?>">#<?= $this->escape($embed_channel->name) ?></a>
-                        <?php } else { ?>
+                    <?php } else { ?>
                         a private channel
-                        <?php } ?>
+                    <?php } ?>
                     </li>
                     <li class="list-inline-item"><a class="message-time text-reset" href="/index/channel/<?= $attachment->channel_id ?>/<?= date('Y-m', $attachment->ts) ?>#ts-<?= $attachment->ts ?>"><?= date('Y-m-d H:i:s', $attachment->ts) ?></a></li>
                 </ul>
             </div>
-            <?php } else { ?>
+        <?php } else { ?>
             <div class="row g-0">
                 <div class="col">
                     <div class="card-body">
@@ -88,33 +87,29 @@ if ($message_data->parent_user_id and !$message_data->is_thread_broadcast) {
                 </div>
                 <?php if ($attachment->image_url) { ?>
                 <div class="col-md-auto">
-                    <img class="attachment-image img-fluid rounded"  src="<?= $this->escape($attachment->image_url) ?>" width="<?= intval($attachment->image_width) ?>" height="<?= intval($attachment->image_height) ?>">
+                    <img class="attachment-image img-fluid rounded" src="<?= $this->escape($attachment->image_url) ?>" width="<?= intval($attachment->image_width) ?>" height="<?= intval($attachment->image_height) ?>">
                 </div>
                 <?php } ?>
             </div>
-            <?php } ?>
+        <?php } ?>
         </blockquote>
-        <?php } ?>
-        <?php } ?>
+    <?php } ?>
+    <?php } ?>
 
-        <?php if (property_exists($message_data, 'reactions')) { ?>
+    <?php if (property_exists($message_data, 'reactions')) { ?>
         <ul class="reactions list-inline my-1">
-            <?php foreach ($message_data->reactions as $reaction) { ?>
+        <?php foreach ($message_data->reactions as $reaction) { ?>
             <li class="list-inline-item badge rounded-pill text-bg-light"><span class="emoji me-1"><?= Message::getEmoji($reaction->name) ?></span><?= $reaction->count ?></li>
-            <?php } ?>
-        </ul>
         <?php } ?>
+        </ul>
+    <?php } ?>
 
-        <?php if (property_exists($message_data, 'replies')) { ?>
+    <?php if (property_exists($message_data, 'replies')) { ?>
         <div class="replies my-2">
-            <?php foreach ($message_data->replies as $reply) { ?>
-            <?php $reply_message = Message::find(array($this->message->channel_id, $reply->ts)) ?>
-            <?php $reply_message_data = json_decode($reply_message->data) ?>
-            <?php if ($reply_message_data->user) { ?>
-                <?php $reply_user_data = json_decode(User::find($reply_message_data->user)->data) ?>
-            <?php } else { ?>
-                <?php $reply_user_data = new stdClass; ?>
-            <?php } ?>
+        <?php foreach ($message_data->replies as $reply) {
+            $reply_message = Message::find([$this->message->channel_id, $reply->ts]);
+            $reply_message_data = json_decode($reply_message->data);
+            $reply_user_data = $reply_message_data->user ? json_decode(User::find($reply_message_data->user)->data) : new stdClass; ?>
             <div class="message d-flex mb-2" id="ts-<?= $reply_message->ts?>">
                 <img class="avatar flex-shrink-0 rounded" src="<?= $this->escape($reply_user_data->profile->image_72) ?>" width="24" height="24">
                 <div class="flex-grow-1 ms-2">
@@ -127,9 +122,9 @@ if ($message_data->parent_user_id and !$message_data->is_thread_broadcast) {
                     </div>
                 </div>
             </div>
-            <?php } ?>
-        </div>
         <?php } ?>
+        </div>
+    <?php } ?>
 
     </div>
 </div>

--- a/webdata/views/index/message.phtml
+++ b/webdata/views/index/message.phtml
@@ -6,7 +6,7 @@ if ($message_data->user and $user = User::find($message_data->user)) {
 } else {
     $avatar = 'https://ca.slack-edge.com/T02G2SXKM-UD94JT3KQ-g8c100274e62-48';
 }
-if (!property_exists($message_data, 'replies') and $this->replies) { 
+if (!property_exists($message_data, 'replies') and $this->replies) {
     $message_data->replies = $this->replies;
     ksort($message_data->replies);
 }
@@ -16,74 +16,91 @@ if ($message_data->parent_user_id and !$message_data->is_thread_broadcast) {
     $style = "display:none";
 }
 ?>
-<div class="message" style="<?= $style ?>" id="ts-<?= $this->message->ts?>">
-    <div class="avatar">
-        <img src="<?= $this->escape($avatar) ?>" width="36" height="36">
+<div class="message d-flex mb-2" style="<?= $style ?>" id="ts-<?= $this->message->ts?>">
+    <div class="avatar flex-shrink-0">
+        <img class="rounded" src="<?= $this->escape($avatar) ?>" width="36" height="36">
     </div>
-    <div class="content">
-        <div>
+    <div class="flex-grow-1 ms-2">
+        <div class="meta">
             <span class="user-name" title="<?= htmlspecialchars(json_encode($user_data, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT)) ?>"><strong><?= $this->escape(Message::getUserName($message_data->user)) ?></strong></span>
             <span class="message-time" title="<?= htmlspecialchars(json_encode($message_data, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT)) ?>"><a href="#ts-<?= $this->message->ts ?>"><?= date('H:i:s', $this->message->ts) ?></a></span>
         </div>
-        <div><?= Message::getHTML($message_data) ?></div>
+        <div class="contents">
+            <?= Message::getHTML($message_data) ?>
+        </div>
 
         <?php if (property_exists($message_data, 'files')) { ?>
         <?php foreach ($message_data->files as $file) { ?>
-        <h5><?= $this->escape($file->title) ?></h5>
-        <img src="<?= $this->escape("/index/file?url=" . urlencode($file->thumb_360)) ?>">
+        <figure class="figure my-2">
+            <img class="attachment-image rounded" src="<?= $this->escape("/index/file?url=" . urlencode($file->thumb_360)) ?>">
+            <figcaption class="figure-caption"><?= $this->escape($file->title) ?></figcaption>
+        </figure>
         <?php } ?>
         <?php } ?>
 
         <?php if (property_exists($message_data, 'attachments')) { ?>
         <?php foreach ($message_data->attachments as $attachment) { ?>
-        <blockquote title="<?= $this->escape(json_encode($attachment, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT)) ?>">
-            <p>
-            <?php if ($attachment->service_icon) { ?>
-            <img src="<?= $this->escape($attachment->service_icon) ?>" width="16" height="16">
-            <?php } ?>
-            <?= $this->escape($attachment->service_name) ?>
-            </p>
-            <p><a href="<?= $this->escape($attachment->title_link) ?>"><?= $this->escape($attachment->title) ?></a></p>
-            <p><?= $this->escape($attachment->text) ?></p>
-            <?php if ($attachment->image_url) { ?>
-            <img src="<?= $this->escape($attachment->image_url) ?>" width="<?= intval($attachment->image_width) ?>" height="<?= intval($attachment->image_height) ?>">
-            <?php } ?>
+        <blockquote class="card my-2" title="<?= $this->escape(json_encode($attachment, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT)) ?>">
+            <div class="row g-0">
+                <div class="col">
+                    <div class="card-body">
+                        <h6 class="card-title">
+                            <?php if ($attachment->service_icon) { ?>
+                            <img class="icon" src="<?= $this->escape($attachment->service_icon) ?>" width="16" height="16">
+                            <?php } ?>
+                            <?= $this->escape($attachment->service_name) ?>
+                        </h6>
+                        <div class="card-subtitle"><a href="<?= $this->escape($attachment->title_link) ?>"><?= $this->escape($attachment->title) ?></a></div>
+                        <div class="card-text">
+                            <?= $this->escape($attachment->text) ?>
+                        </div>
+                    </div>
+                </div>
+                <?php if ($attachment->image_url) { ?>
+                <div class="col-md-auto">
+                    <img class="attachment-image img-fluid rounded"  src="<?= $this->escape($attachment->image_url) ?>" width="<?= intval($attachment->image_width) ?>" height="<?= intval($attachment->image_height) ?>">
+                </div>
+                <?php } ?>
+            </div>
         </blockquote>
         <?php } ?>
         <?php } ?>
 
-        <?php if (property_exists($message_data, 'replies')) { ?>
-        <?php foreach ($message_data->replies as $reply) { ?>
-        <?php $reply_message = Message::find(array($this->message->channel_id, $reply->ts)) ?>
-        <?php $reply_message_data = json_decode($reply_message->data) ?>
-
-        <?php if ($reply_message_data->user) { ?>
-        <?php $reply_user_data = json_decode(User::find($reply_message_data->user)->data) ?>
-        <?php } else { ?>
-        <?php $reply_user_data = new stdClass; ?>
-        <?php } ?>
-        <div style="padding-top: 5px">
-            <div class="avatar" width="30px">
-                <img src="<?= $this->escape($reply_user_data->profile->image_72) ?>" width="24" height="24">
-            </div>
-            <div class="content">
-                <div>
-                    <span class="user-name" title="<?= htmlspecialchars(json_encode($reply_user_data, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT)) ?>"><strong><?= $this->escape(Message::getUserName($reply_message_data->user)) ?></strong></span>
-                    <span class="message-time" title="<?= htmlspecialchars(json_encode($reply_message_data, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT)) ?>"><a href="#ts-<?= $reply_message->ts ?>"><?= date('Y-m-d H:i:s', $reply_message->ts) ?></a></span>
-                </div>
-                <div><?= Message::getHTML($reply_message_data) ?></div>
-            </div>
-            <div style="clear: both"></div>
-        </div>
-        <?php } ?>
-        <?php } ?>
-
         <?php if (property_exists($message_data, 'reactions')) { ?>
-        <div>
+        <ul class="reactions list-inline my-1">
             <?php foreach ($message_data->reactions as $reaction) { ?>
-            <span class="badge"><?= Message::getEmoji($reaction->name) ?> <?= $reaction->count ?></span>
+            <li class="list-inline-item badge rounded-pill text-bg-light"><?= Message::getEmoji($reaction->name) ?> <?= $reaction->count ?></li>
+            <?php } ?>
+        </ul>
+        <?php } ?>
+
+        <?php if (property_exists($message_data, 'replies')) { ?>
+        <div class="replies my-2">
+            <?php foreach ($message_data->replies as $reply) { ?>
+            <?php $reply_message = Message::find(array($this->message->channel_id, $reply->ts)) ?>
+            <?php $reply_message_data = json_decode($reply_message->data) ?>
+            <?php if ($reply_message_data->user) { ?>
+                <?php $reply_user_data = json_decode(User::find($reply_message_data->user)->data) ?>
+            <?php } else { ?>
+                <?php $reply_user_data = new stdClass; ?>
+            <?php } ?>
+            <div class="message d-flex mb-2" id="ts-<?= $reply_message->ts?>">
+                <div class="avatar flex-shrink-0">
+                    <img src="<?= $this->escape($reply_user_data->profile->image_72) ?>" width="24" height="24">
+                </div>
+                <div class="flex-grow-1 ms-2">
+                    <div class="meta">
+                        <span class="user-name" title="<?= htmlspecialchars(json_encode($reply_user_data, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT)) ?>"><strong><?= $this->escape(Message::getUserName($reply_message_data->user)) ?></strong></span>
+                        <span class="message-time" title="<?= htmlspecialchars(json_encode($reply_message_data, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT)) ?>"><a href="#ts-<?= $reply_message->ts ?>"><?= date('Y-m-d H:i:s', $reply_message->ts) ?></a></span>
+                    </div>
+                    <div class="contents">
+                        <?= Message::getHTML($reply_message_data) ?>
+                    </div>
+                </div>
+            </div>
             <?php } ?>
         </div>
         <?php } ?>
+
     </div>
 </div>

--- a/webdata/views/index/message.phtml
+++ b/webdata/views/index/message.phtml
@@ -11,18 +11,25 @@ if (!property_exists($message_data, 'replies') and $this->replies) {
     ksort($message_data->replies);
 }
 
-$style = '';
+$classes = '';
 if ($message_data->parent_user_id and !$message_data->is_thread_broadcast) {
-    $style = "display:none";
+    $classes = "thread-message";
 }
 ?>
-<div class="message d-flex mb-2" style="<?= $style ?>" id="ts-<?= $this->message->ts?>">
-    <img class="avatar flex-shrink-0 rounded" src="<?= $this->escape($avatar) ?>" width="36" height="36">
+<div class="message d-flex mb-2 <?= $classes ?>" id="ts-<?= $this->message->ts?>">
+    <img class="avatar flex-shrink-0 rounded-3 mt-1" src="<?= $this->escape($avatar) ?>" width="36" height="36">
     <div class="flex-grow-1 ms-2">
         <div class="meta">
             <span class="user-name" title="<?= htmlspecialchars(json_encode($user_data, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT)) ?>"><strong><?= $this->escape(Message::getUserName($message_data->user)) ?></strong></span>
-            <span class="message-time" title="<?= htmlspecialchars(json_encode($message_data, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT)) ?>"><a href="#ts-<?= $this->message->ts ?>"><?= date('H:i:s', $this->message->ts) ?></a></span>
+            <span class="message-time small" title="<?= htmlspecialchars(json_encode($message_data, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT)) ?>"><a class="link-secondary link-underline link-underline-opacity-0 link-underline-opacity-75-hover" href="#ts-<?= $this->message->ts ?>"><?= date('H:i:s', $this->message->ts) ?></a></span>
         </div>
+
+        <?php if($message_data->subtype == "thread_broadcast" and property_exists($message_data, 'root')) { ?>
+        <div class="thread-root">
+            Replied to a thread: <a class="link-underline link-underline-opacity-0 link-underline-opacity-75-hover" href="/index/channel/<?= $this->message->channel_id ?>/<?= date('Y-m', $message_data->thread_ts) ?>#ts-<?= $message_data->thread_ts ?>"><?= date('Y-m-d H:i:s', $message_data->thread_ts) ?></a>
+        </div>
+        <?php } ?>
+
         <div class="contents">
             <?= Message::getHTML($message_data) ?>
         </div>
@@ -113,7 +120,7 @@ if ($message_data->parent_user_id and !$message_data->is_thread_broadcast) {
                 <div class="flex-grow-1 ms-2">
                     <div class="meta">
                         <span class="user-name" title="<?= htmlspecialchars(json_encode($reply_user_data, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT)) ?>"><strong><?= $this->escape(Message::getUserName($reply_message_data->user)) ?></strong></span>
-                        <span class="message-time" title="<?= htmlspecialchars(json_encode($reply_message_data, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT)) ?>"><a href="#ts-<?= $reply_message->ts ?>"><?= date('Y-m-d H:i:s', $reply_message->ts) ?></a></span>
+                        <span class="message-time small" title="<?= htmlspecialchars(json_encode($reply_message_data, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT)) ?>"><a class="link-secondary link-underline link-underline-opacity-0 link-underline-opacity-75-hover" href="#ts-<?= $reply_message->ts ?>"><?= date('Y-m-d H:i:s', $reply_message->ts) ?></a></span>
                     </div>
                     <div class="contents">
                         <?= Message::getHTML($reply_message_data) ?>

--- a/webdata/views/index/search.phtml
+++ b/webdata/views/index/search.phtml
@@ -28,25 +28,40 @@ if ($channel_ids) {
 ?>
 <?= $this->partial('common/header.phtml', $this) ?>
 <style>
-.message .avatar {
-    float: left;
-    padding-right: 5px;
+.badge .emoji {
+    font-size: 16px;
 }
 
-.message .content {
-    overflow: hidden;
-    padding-bottom: 10px;
+.badge .emoji > img {
+    aspect-ratio: auto;
+    max-width: 16px;
+    max-height: 16px;
 }
 
-.message {
-    clear: both;
+.attachment-image {
+    aspect-ratio: auto;
+}
+
+@media screen and (min-width: 48rem) {
+    .attachment-image {
+        max-width: 24rem;
+        max-height: 24rem;
+    }
 }
 </style>
-<?php foreach ($messages as $message) { ?>
-<?php if (!array_key_exists($message->channel_id, $channels)) { continue; } ?>
-<h3><a href="/index/channel/<?= $message->channel_id ?>/<?= date('Y-m', $message->ts) ?>#ts-<?= $message->ts ?>">#<?= $this->escape($channels[$message->channel_id]->name) ?>. <?= date('Y-m-d H:i:s', $message->ts) ?></a></h3></h3>
-<?= $this->partial('/index/message.phtml', array('message' => $message)) ?>
-<?php } ?>
-<div style="clear:both"></div>
-<?= $this->partial('common/footer.phtml', $this) ?>
 
+<main class="container my-4">
+<h2>Search: <q class="text-body-secondary small"><?= $this->escape($this->q) ?></q></h2>
+<ol class="list-group my-4" aria-label="Results">
+    <?php foreach ($messages as $message) { ?>
+    <?php if (!array_key_exists($message->channel_id, $channels)) { continue; } ?>
+    <li class="list-group-item list-group-item-action">
+        <div class="d-flex w-100 justify-content-between mb-1">
+            <strong>#<?= $this->escape($channels[$message->channel_id]->name) ?></strong>
+            <a href="/index/channel/<?= $message->channel_id ?>/<?= date('Y-m', $message->ts) ?>#ts-<?= $message->ts ?>" class="link-secondary small stretched-link"><?= date('Y-m-d H:i:s', $message->ts) ?></a>
+        </div>
+        <?= $this->partial('/index/message.phtml', array('message' => $message)) ?>
+    </li>
+    <?php } ?>
+</ol>
+<?= $this->partial('common/footer.phtml', $this) ?>

--- a/webdata/views/index/search.phtml
+++ b/webdata/views/index/search.phtml
@@ -1,15 +1,17 @@
 <?php
 
-$this->title = "# Search [" . $this->q . "]";
-$this->messages = Message::search('data->>\'text\' LIKE ' . Message::getDb()->quoteWithColumn('data', '%' . $this->q . '%'))->limit(100);
-$channel_ids = array();
-$messages = array();
+$this->title = "# Search [{$this->q}]";
+$this->messages = Message::search('data->>\'text\' LIKE ' . Message::getDb()->quoteWithColumn('data', "%{$this->q}%"))->limit(100);
+
+$channel_ids = [];
+$messages = [];
 foreach ($this->messages as $message) {
     $channel_ids[$message->channel_id] = $message->channel_id;
     $messages[] = $message;
 }
-usort($messages, function($a, $b) { return $b->ts - $a->ts; });
-$channels = array();
+usort($messages, fn($a, $b) => ($b->ts - $a->ts));
+
+$channels = [];
 if ($channel_ids) {
     foreach (Channel::search(1)->searchIn('id', array_keys($channel_ids)) as $channel) {
         $data = json_decode($channel->data);
@@ -17,7 +19,7 @@ if ($channel_ids) {
             if (!$this->user->id) {
                 continue;
             }
-            if (!ChannelUser::search(array('channel_id' => $channel->id, 'user_id' => $this->user->id))->count()) {
+            if (!ChannelUser::search(['channel_id' => $channel->id, 'user_id' => $this->user->id])->count()) {
                 continue;
             }
         }
@@ -50,18 +52,20 @@ if ($channel_ids) {
 }
 </style>
 
-<main class="container my-4">
-<h2>Search: <q class="text-body-secondary small"><?= $this->escape($this->q) ?></q></h2>
-<ol class="list-group my-4" aria-label="Results">
-    <?php foreach ($messages as $message) { ?>
-    <?php if (!array_key_exists($message->channel_id, $channels)) { continue; } ?>
-    <li class="list-group-item list-group-item-action">
-        <div class="d-flex w-100 justify-content-between mb-1">
-            <strong>#<?= $this->escape($channels[$message->channel_id]->name) ?></strong>
-            <a href="/index/channel/<?= $message->channel_id ?>/<?= date('Y-m', $message->ts) ?>#ts-<?= $message->ts ?>" class="link-secondary small stretched-link"><?= date('Y-m-d H:i:s', $message->ts) ?></a>
-        </div>
-        <?= $this->partial('/index/message.phtml', array('message' => $message)) ?>
-    </li>
+<section class="container my-4">
+    <h2>Search: <q class="text-body-secondary small"><?= $this->escape($this->q) ?></q></h2>
+    <ol class="list-group my-4" aria-label="Results">
+    <?php foreach ($messages as $message) {
+        if (!array_key_exists($message->channel_id, $channels)) { continue; } ?>
+        <li class="list-group-item list-group-item-action">
+            <div class="d-flex w-100 justify-content-between mb-1">
+                <strong>#<?= $this->escape($channels[$message->channel_id]->name) ?></strong>
+                <a href="/index/channel/<?= $message->channel_id ?>/<?= date('Y-m', $message->ts) ?>#ts-<?= $message->ts ?>" class="link-secondary small stretched-link"><?= date('Y-m-d H:i:s', $message->ts) ?></a>
+            </div>
+            <?= $this->partial('/index/message.phtml', ['message' => $message]) ?>
+        </li>
     <?php } ?>
-</ol>
+    </ol>
+</section>
+
 <?= $this->partial('common/footer.phtml', $this) ?>


### PR DESCRIPTION
嗨咿 @ronnywang！因為在找歷史紀錄的時候發現 Slack archive 有部分資料沒有呈現出來，所以趁連假豁出去把 Slack archive 前後拉皮了一番。這個 PR 對專案做了以下的整理：

* 將 Bootstrap 從 v2.2 升至 v.5.3.8、更新關聯套件
* 改善首頁與其他頁面的 RWD 支援
* 改善訊息、訊息附件、搜尋頁呈現的方式
* 加入對轉發訊息、回應討論串的支援
* 月份按照年份折疊
* 依照 `phptools` linter 的建議，部分改用 PHP 7 的語法

因為我沒有 production 環境，還想請 Ronny 先測測看有什麼問題！其他過程中有注意到的小 bug 我先去開 issue，之後可以看要怎麼修。ᶘ ᵒᴥᵒᶅ